### PR TITLE
Modernize Docker config & fix versions

### DIFF
--- a/.docker/openssl/Dockerfile
+++ b/.docker/openssl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.21
 
 # Install OpenSSL
 RUN apk update && \

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ doctrine:
     dbal:
       driver: 'pdo_pgsql'
       url: '%env(DATABASE_URL)%'
-      server_version: '12.2'
+      server_version: '17'
       sslmode: 'verify-ca' # 'verify-full' for production
       sslrootcert: '%env(POSTGRES_SSL_CA)%'
       sslcert: '%env(POSTGRES_SSL_CERT)%'

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -9,7 +9,7 @@ services:
       - db
 
   database_app:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: database_app
     networks:
       - db
@@ -18,6 +18,7 @@ services:
       MYSQL_DATABASE: db_name
       MYSQL_USER: db_user
       MYSQL_PASSWORD: db_password
+    restart: unless-stopped
     volumes:
       - db_data:/var/lib/mysql
       - certs:/etc/certs
@@ -31,7 +32,7 @@ services:
                "--ssl-ca=/etc/certs/ca-cert.pem",
                "--ssl-cert=/etc/certs/server-cert.pem",
                "--ssl-key=/etc/certs/server-key.pem",
-               "--default_authentication_plugin=mysql_native_password" ]
+               "--authentication_policy=caching_sha2_password" ]
 
 volumes:
   db_data:

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,6 +1,6 @@
 services:
   php_app:
-    image: php:8.3-fpm-alpine
+    image: php:8.4-fpm-alpine
     container_name: php_app
     volumes:
       - .:/app
@@ -9,7 +9,7 @@ services:
       - db
 
   database_app:
-    image: postgres:latest
+    image: postgres:17
     container_name: database_app
     networks:
       - db


### PR DESCRIPTION
## Summary
- **PHP 8.4** aligné dans le fichier PostgreSQL (était 8.3)
- **Pin des versions** : `postgres:17` (était `:latest`), `alpine:3.21` (était `:latest`), `mysql:8.4` (était `8.0`)
- **Auth MySQL** : remplace `mysql_native_password` (déprécié) par `caching_sha2_password`
- **Restart policy** ajoutée au service MySQL (`unless-stopped`)
- **Typo corrigée** : `docker-compose.posgres.yml` → `docker-compose.postgres.yml`
- **README** : `server_version` Doctrine mis à jour pour PostgreSQL 17